### PR TITLE
remove DISPLAY because xvfb-run -a handles it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,6 @@ COPY config.json /opt/selenium/config.json
 ENV SCREEN_WIDTH 1360
 ENV SCREEN_HEIGHT 1020
 ENV SCREEN_DEPTH 24
-ENV DISPLAY :99.0
 
 # https://github.com/SeleniumHQ/docker-selenium/blob/master/StandaloneFirefox/Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ COPY config.json /opt/selenium/config.json
 ENV SCREEN_WIDTH 1360
 ENV SCREEN_HEIGHT 1020
 ENV SCREEN_DEPTH 24
+ENV DISPLAY :99.0
 
 # https://github.com/SeleniumHQ/docker-selenium/blob/master/StandaloneFirefox/Dockerfile
 

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -9,7 +9,7 @@ function shutdown {
   wait $NODE_PID
 }
 
-xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
+xvfb-run --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar ${JAVA_OPTS} &
 NODE_PID=$!
 

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -9,7 +9,8 @@ function shutdown {
   wait $NODE_PID
 }
 
-xvfb-run --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+SERVERNUM=$(echo $DISPLAY | sed 's/:\([0-9][0-9]*\).[0-9][0-9]*/\1/')
+xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar ${JAVA_OPTS} &
 NODE_PID=$!
 


### PR DESCRIPTION
I've been seeing "xvfb-run: error: Xvfb failed to start" in the startup logs for cloudbees/jnlp-slave-with-java-build-tools.

Per this reference: https://github.com/travis-ci/travis-ci/issues/4387

It looks the -a option (choose any available display) is preferred over the environment variable.

Have not tested, as I use the JNLP variant..